### PR TITLE
Fix TEST_WAVE_WRAPPER

### DIFF
--- a/docu/examples/example4-wavechecking.ipf
+++ b/docu/examples/example4-wavechecking.ipf
@@ -24,10 +24,10 @@ End
 static Function CheckMakeText()
 	CHECK_EMPTY_FOLDER()
 
-	Make/T/D myWave
+	Make/T myWave
 	CHECK_WAVE(myWave,TEXT_WAVE)
 	CHECK_EQUAL_VAR(DimSize(myWave,0),128)
 
-	Duplicate myWave, myWaveCopy
+	Duplicate/T myWave, myWaveCopy
 	CHECK_EQUAL_WAVES(myWave,myWaveCopy)
 End

--- a/procedures/unit-testing-comparators.ipf
+++ b/procedures/unit-testing-comparators.ipf
@@ -373,7 +373,7 @@ End
 /// @param majorType  major wave type
 /// @param minorType  (optional) minor wave type
 /// @see testWaveFlags
-static Function TEST_WAVE_WRAPPER(wv, flags, majorType, [minorType])
+static Function TEST_WAVE_WRAPPER(wv, majorType, flags, [minorType])
 	Wave/Z wv
 	variable majorType, minorType
 	variable flags

--- a/procedures/unit-testing-comparators.ipf
+++ b/procedures/unit-testing-comparators.ipf
@@ -399,7 +399,7 @@ static Function TEST_WAVE_WRAPPER(wv, majorType, flags, [minorType])
 		endif
 	endif
 
-	result = (WaveType(wv, 1) != majorType)
+	result = (WaveType(wv, 1) == majorType)
 	string str
 	sprintf str, "Assumption that the wave's main type is %d", majorType
 	DebugOutput(str, result)


### PR DESCRIPTION
I fixed your comprehensive unit-testing-framework a little bit.

In old version, checking for text waves is not work.
```
CHECK_WAVE({0,1,2}, TEXT_WAVE) // This test passes. 
``` 

I fixed TEST_WAVE_WRAPPER function and example4-wavechecking.ipf.
